### PR TITLE
Fixed naming inconsistency of protocol/delegate

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Optionally, you can require the user to enter B+A+Enter in order for the gesture
 }
 
 #pragma mark -
-#pragma mark DRKonamiRecognizerDelegate
+#pragma mark DRKonamiGestureProtocol
 
 - (void)DRKonamiGestureRecognizerNeedsABEnterSequence:(DRKonamiGestureRecognizer*)gesture
 {

--- a/Sources/DRKonamiGestureRecognizer.h
+++ b/Sources/DRKonamiGestureRecognizer.h
@@ -6,8 +6,7 @@
 //
 
 /**
- DRKonamiGestureProtocol is optional! If you are using the delegate then you must implement all of the required methods.
- 
+ The delegate (DRKonamiGestureProtocol) is optional! If you are using the delegate, however, then you must implement all of the required methods. The delegate is only needed if you wish to include A+B+Enter as the final steps of the Konami sequence.
  The Konami Gesture protocol implements communication between the gesture recognizer and the delegate when the A+B+Enter action is required to complete the gesture. If the A+B+Enter sequence is not used then none of the protocol methods are required.
  */
 @class DRKonamiGestureRecognizer;
@@ -23,12 +22,13 @@
  Informs the delegate that the gesture recognizer no longers requires the B+A+Enter sequence. This will happen either because the sequence has succeeded or failed. This is where you can remove the B+A+Enter options from the screen.
  */
 - (void)DRKonamiGestureRecognizer:(DRKonamiGestureRecognizer*)gesture didFinishNeedingABEnterSequenceWithError:(BOOL)error;
+
 @end
 
 //////////////////////////////////////////////////////////////////////
 
 /**
- Konami code states.
+ Konami code states.  Mostly used internally, but you will need to use 'DRKonamiGestureStateRecognized'.
  */
 typedef enum DRKonamiGestureState
 {
@@ -75,6 +75,11 @@ typedef enum DRKonamiGestureState
 - (void) AButtonAction;
 - (void) BButtonAction;
 - (void) enterButtonAction;
+
+/**
+ Cancels the gesture recognizer from waiting on the A+B+Enter sequence. Also sets the gesture recognizer state to failed.
+ Used by the delegate (if delegate exists).
+ */
 - (void) cancelSequence;
 
 @end

--- a/Sources/DRViewController.m
+++ b/Sources/DRViewController.m
@@ -9,6 +9,7 @@
 
 @interface DRViewController()
 - (void)_konamiGestureRecognized:(DRKonamiGestureRecognizer*)gesture;
+@property (nonatomic) UILabel *nesLabel;
 @end
 
 #pragma mark -
@@ -29,8 +30,23 @@
     [self.konamiGestureRecognizer setKonamiDelegate:self];
     [self.konamiGestureRecognizer setRequiresABEnterToUnlock:YES];
     [self.view addGestureRecognizer:self.konamiGestureRecognizer];
-
-    [self.NESControllerView setHidden:YES];
+    
+    if ( !self.nesLabel )
+    {
+        UILabel *nesLabel = [[UILabel alloc] initWithFrame:CGRectMake(10, CGRectGetMaxY(self.NESControllerView.frame), CGRectGetWidth(self.view.bounds)-20, 66)];
+        nesLabel.text = @"Hit B, then A, then the enter button (right button in middle of NES controller) to finish Konami sequence.";
+        nesLabel.numberOfLines = 0;
+        [nesLabel setFont:[UIFont systemFontOfSize:15]];
+        nesLabel.textAlignment = NSTextAlignmentCenter;
+        [self.view addSubview:nesLabel];
+        nesLabel.autoresizingMask = UIViewAutoresizingFlexibleBottomMargin;
+        self.nesLabel = nesLabel;
+    }
+    
+    // initially hidden. Shown when user has completed the Konami sequence up to the A+B+Enter part.
+    self.NESControllerView.alpha = 0;
+    self.NESControllerView.transform = CGAffineTransformMakeScale(.8, .8);
+    self.nesLabel.alpha = 0;
 
     self.statusLabel.text = nil;
 }
@@ -43,16 +59,25 @@
 }
 
 #pragma mark -
-#pragma mark DRKonamiRecognizerDelegate
+#pragma mark DRKonamiGestureProtocol
 
 - (void)DRKonamiGestureRecognizerNeedsABEnterSequence:(DRKonamiGestureRecognizer*)gesture
 {
-    [self.NESControllerView setHidden:NO];
+    [UIView animateWithDuration:0.3 animations:^{
+        self.NESControllerView.alpha = 1;
+        self.NESControllerView.transform = CGAffineTransformIdentity;
+        self.nesLabel.alpha = 1;
+    }];
 }
 
 - (void)DRKonamiGestureRecognizer:(DRKonamiGestureRecognizer*)gesture didFinishNeedingABEnterSequenceWithError:(BOOL)error
 {
-    [self.NESControllerView setHidden:YES];
+    [UIView animateWithDuration:0.3 animations:^{
+        self.NESControllerView.alpha = 0;
+        self.NESControllerView.transform = CGAffineTransformMakeScale(.8, .8);
+        self.nesLabel.alpha = 0;
+    }];
+
 }
 
 #pragma mark -


### PR DESCRIPTION
1. Fixed naming inconsistency caused by using both DRKonamiGestureProtocol and DRKonamiGestureDelegate.
2. Updated the example project to have more instructions about how to finish the B+A+Enter sequence
